### PR TITLE
Correct exception handling in spectre.py

### DIFF
--- a/src/spectre.py
+++ b/src/spectre.py
@@ -112,7 +112,7 @@ class SPECTRE(nn.Module):
             except Exception as e:
                 print(f'Missing keys {e} in expression encoder weights. If starting training from scratch this is normal.')
         else:
-            raise(f'please check model path: {model_path}')
+            raise RuntimeError(f'please check model path: {model_path}')
 
         # eval mode
         self.E_flame.eval()


### PR DESCRIPTION
Fix: Correct exception handling in spectre.py by raising RuntimeError instead of string